### PR TITLE
Fix Rails logger reference

### DIFF
--- a/app/middleware/workspaces_elevator.rb
+++ b/app/middleware/workspaces_elevator.rb
@@ -9,7 +9,7 @@ class WorkspacesElevator < Apartment::Elevators::Generic
     return nil if workspace_id.blank?
     return nil unless workspace_id.match?(/^\d+$/)
 
-    logger.info("Selecting workspace #{workspace_id}")
+    Rails.logger.info("Selecting workspace #{workspace_id}")
 
     "workspace-#{workspace_id}"
   end


### PR DESCRIPTION
A recent rebase updated dependencies that removed `logger` from the global namespace. This fixes the reference for Workspaces functionality.