### PR TITLE
Fix migrations references for tenant schemas

### DIFF
--- a/db/migrate/20240605134916_add_notes_and_diary_comments_counter_caches.rb
+++ b/db/migrate/20240605134916_add_notes_and_diary_comments_counter_caches.rb
@@ -1,5 +1,9 @@
 class AddNotesAndDiaryCommentsCounterCaches < ActiveRecord::Migration[7.1]
   def self.up
+    if connection.current_schema.start_with?("workspace-")
+      return # Ignore this migration in workspace tenant schemas
+    end
+
     add_column :users, :diary_comments_count, :integer, :default => 0
     add_column :users, :note_comments_count, :integer, :default => 0
 

--- a/db/migrate/20240910175616_add_user_creation_address.rb
+++ b/db/migrate/20240910175616_add_user_creation_address.rb
@@ -2,6 +2,10 @@ class AddUserCreationAddress < ActiveRecord::Migration[7.1]
   disable_ddl_transaction!
 
   def change
+    if connection.current_schema.start_with?("workspace-")
+      return # Ignore this migration in workspace tenant schemas
+    end
+
     add_column :users, :creation_address, :inet
     add_index :users, :creation_address, :using => :gist, :opclass => :inet_ops, :algorithm => :concurrently
   end

--- a/db/migrate/20240912181413_backfill_user_creation_address.rb
+++ b/db/migrate/20240912181413_backfill_user_creation_address.rb
@@ -3,6 +3,10 @@ class BackfillUserCreationAddress < ActiveRecord::Migration[7.1]
   end
 
   def up
+    if connection.current_schema.start_with?("workspace-")
+      return # Ignore this migration in workspace tenant schemas
+    end
+
     User
       .where(:creation_address => nil)
       .where.not(:creation_ip => nil)

--- a/db/migrate/20240913171951_drop_user_creation_ip.rb
+++ b/db/migrate/20240913171951_drop_user_creation_ip.rb
@@ -1,5 +1,9 @@
 class DropUserCreationIp < ActiveRecord::Migration[7.1]
   def change
+    if connection.current_schema.start_with?("workspace-")
+      return # Ignore this migration in workspace tenant schemas
+    end
+
     safety_assured { remove_column :users, :creation_ip, :string }
   end
 end

--- a/db/migrate/20241022141247_create_note_subscriptions.rb
+++ b/db/migrate/20241022141247_create_note_subscriptions.rb
@@ -1,7 +1,7 @@
 class CreateNoteSubscriptions < ActiveRecord::Migration[7.2]
   def change
     create_table :note_subscriptions, :primary_key => [:user_id, :note_id] do |t|
-      t.references :user, :foreign_key => true, :index => false
+      t.references :user, :foreign_key => { :to_table => "public.users" }, :index => false
       t.references :note, :foreign_key => true
     end
   end

--- a/db/migrate/20241030090336_add_user_location_name.rb
+++ b/db/migrate/20241030090336_add_user_location_name.rb
@@ -1,5 +1,9 @@
 class AddUserLocationName < ActiveRecord::Migration[7.2]
   def change
+    if connection.current_schema.start_with?("workspace-")
+      return # Ignore this migration in workspace tenant schemas
+    end
+
     add_column :users, :home_location_name, :string
   end
 end

--- a/db/migrate/20250104140952_add_description_to_notes.rb
+++ b/db/migrate/20250104140952_add_description_to_notes.rb
@@ -4,6 +4,6 @@ class AddDescriptionToNotes < ActiveRecord::Migration[7.2]
     add_column :notes, :user_id, :bigint
     add_column :notes, :user_ip, :inet
 
-    add_foreign_key :notes, :users, :column => :user_id, :name => "notes_user_id_fkey", :validate => false
+    add_foreign_key :notes, "public.users", :column => :user_id, :name => "notes_user_id_fkey", :validate => false
   end
 end

--- a/db/migrate/20250105154621_validate_foreign_key_on_notes.rb
+++ b/db/migrate/20250105154621_validate_foreign_key_on_notes.rb
@@ -1,5 +1,5 @@
 class ValidateForeignKeyOnNotes < ActiveRecord::Migration[7.2]
   def change
-    validate_foreign_key :notes, :users
+    validate_foreign_key :notes, "public.users"
   end
 end

--- a/db/migrate/20250217140049_create_social_links.rb
+++ b/db/migrate/20250217140049_create_social_links.rb
@@ -1,5 +1,9 @@
 class CreateSocialLinks < ActiveRecord::Migration[7.2]
   def change
+    if connection.current_schema.start_with?("workspace-")
+      return # Ignore this migration in workspace tenant schemas
+    end
+
     create_table :social_links do |t|
       t.references :user, :null => false, :foreign_key => true
       t.string :url, :null => false

--- a/db/migrate/20250506052030_add_company_to_users.rb
+++ b/db/migrate/20250506052030_add_company_to_users.rb
@@ -1,5 +1,9 @@
 class AddCompanyToUsers < ActiveRecord::Migration[8.0]
   def change
+    if connection.current_schema.start_with?("workspace-")
+      return # Ignore this migration in workspace tenant schemas
+    end
+
     add_column :users, :company, :string
   end
 end

--- a/db/migrate/20251028201000_create_team.rb
+++ b/db/migrate/20251028201000_create_team.rb
@@ -1,5 +1,9 @@
 class CreateTeam < ActiveRecord::Migration[7.1]
   def up
+    if connection.current_schema.start_with?("workspace-")
+      return # Ignore this migration in workspace tenant schemas
+    end
+
     create_table :teams do |t|
       t.bigint :workspace_id
       t.string :name
@@ -17,7 +21,7 @@ class CreateTeam < ActiveRecord::Migration[7.1]
     add_foreign_key :team_user, :teams, column: :team_id,  validate: false
     add_foreign_key :team_user, :users, column: :user_id,  validate: false
   end
-  
+
   def down
     drop_table :team_user
     drop_table :teams


### PR DESCRIPTION
This change prevents issues with table references while running migrations for tenant schemas by:

 - Skipping migrations for the `users` table
 - Qualifying foreign key references of the `users` table with the `public` prefix